### PR TITLE
Update wiz-device.html

### DIFF
--- a/wiz-device.html
+++ b/wiz-device.html
@@ -5,7 +5,8 @@
     category: "WiZ",
     defaults: {
       wiz_config: { value: undefined, type: "wiz-config", required: true },
-      ip: { value: "", required: true }
+      ip: { value: "", required: true },
+      name: { value: "", required: false}
     },
     inputs: 1,
     outputs: 7,


### PR DESCRIPTION
Without adding the field name to the defaults field it won't save the filled input value.